### PR TITLE
max_iter of should be 500K

### DIFF
--- a/prototxt/s1_solver.prototxt.template
+++ b/prototxt/s1_solver.prototxt.template
@@ -17,9 +17,9 @@ power: 0.75
 
 display: 200
 
-max_iter: 100000
+max_iter: 500000 
 
-snapshot: 10000
+snapshot: 50000
 snapshot_prefix: "model/{level}_{name}/"
 
 test_compute_loss: true


### PR DESCRIPTION
according to the change made in m2 in common/cnns.py
